### PR TITLE
Draft code of conduct

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ header_pages:
  - 2020-workshop.md
  - assoc.md
  - contact.md
+ - code-of-conduct.md
 # - communication.md
 
 # Build settings

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -84,7 +84,7 @@ information.
 
 The important information we need consists of:
 - Identifying information (name) of the participant doing the harassing
-- The behaviour that was in violation
+- The behaviour that was potentially in violation
 - The approximate time of the behaviour (if different than the time the report was made)
 - The circumstances surrounding the incident
 - Other people involved in the incident

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -93,7 +93,7 @@ After the code of conduct committee receives a report, a decision will be made
 as quickly as possible and any decisions made by the code of conduct will be
 enforced immediately.
 
-The code of conduct committee is well informed on how to deal with the incident
+The code of conduct committee is well informed on how to deal with an incident.
 and how to further proceed with the situation.  All of our committee members
 are informed of the code of conduct policy and guide for handling harassment at
 the workshop. There will be a mandatory meeting for the code of conduct

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -94,7 +94,7 @@ as quickly as possible and any decisions made by the code of conduct will be
 enforced immediately.
 
 The code of conduct committee is well informed on how to deal with an incident.
-and how to further proceed with the situation.  All of our committee members
+All of our committee members
 are knowledgable about the code of conduct policy and how to handle harassment at
 the workshop. There will be a mandatory meeting for the code of conduct
 committee members just prior to the event when this will be reiterated as well.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -95,6 +95,6 @@ enforced immediately.
 
 The code of conduct committee is well informed on how to deal with an incident.
 and how to further proceed with the situation.  All of our committee members
-are informed of the code of conduct policy and guide for handling harassment at
+are knowledgable about the code of conduct policy and how to handle harassment at
 the workshop. There will be a mandatory meeting for the code of conduct
 committee members just prior to the event when this will be reiterated as well.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -70,7 +70,7 @@ If you are being harassed, notice that someone else is being harassed, or have
 any other concerns, please contact any member of the code of conduct committee
 via email or direct message using the workshop Slack chat:
 
-- Anne Fouilloux
+- Anne Fouilloux (annefou@uio.no)
 - Ian Cosden
 - Radovan Bast (radovan.bast@uit.no)
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -74,7 +74,6 @@ via email or direct message using the workshop Slack chat:
 - Ian Cosden
 - Radovan Bast (radovan.bast@uit.no)
 
-
 Report the harassment incident via email to a member of the code of conduct
 committee. All reports are confidential.
 
@@ -89,6 +88,10 @@ The important information we need consists of:
 - The approximate time of the behaviour (if different than the time the report was made)
 - The circumstances surrounding the incident
 - Other people involved in the incident
+
+After the code of conduct committee receives a report, a decision will be made
+as quickly as possible and any decisions made by the code of conduct will be
+enforced immediately.
 
 The code of conduct committee is well informed on how to deal with the incident
 and how to further proceed with the situation.  All of our committee members

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -61,7 +61,7 @@ Excessive swearing is not appropriate at this event.
 
 If a participant engages in behaviour that violates this code of conduct, the
 workshop organisers may take any action they deem appropriate, including
-warning the offender or expulsion from the workshop with no refund.
+warning the offender or expulsion from the workshop.
 
 
 ## Procedure for reporting harassment

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,93 @@
+---
+layout: default
+---
+
+# Code of conduct
+
+> This code of conduct is copied and adapted from the code of conduct used at the
+> [Collaborations Workshop 2020](https://www.software.ac.uk/cw20/code-conduct)
+> (CC-BY-NC 2.5 license) which was adapted from the example policy at the
+> [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy),
+> created by the Ada Initiative and other volunteers (CC-0 license).
+> The procedure for reporting harassment has been adopted from the Ada Initiative's guide titled
+> ["workshop anti-harassment/Responding to Reports"](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports).
+
+We value the participation of each stakeholder and want all participants to
+have an enjoyable and fulfilling experience. Accordingly, all participants are
+expected to show respect and courtesy to other participants throughout the
+event and through all communication channels.
+
+To make clear what is expected, all participants, speakers, organisers and
+volunteers at 2nd International RSE Leaders Meeting are required to conform to
+the following code of conduct. Organisers will enforce this code throughout the
+event.
+
+
+## Summary
+
+We are dedicated to providing a harassment-free workshop experience for
+everyone. We do not tolerate harassment of workshop participants in any form.
+
+All communication should be appropriate for a professional audience including
+people of many different backgrounds.
+
+Be kind to others. Do not insult or put down other attendees.
+
+Behave professionally. Remember that harassment, unprofessional remarks and
+messages, and exclusionary jokes are not appropriate at the 2nd International
+RSE Leaders Meeting.
+
+Participants violating these rules may be asked to leave the workshop
+at the sole discretion of the workshop organisers.
+
+Thank you for helping make this a welcoming, friendly event for all.
+
+
+## Clarifications
+
+Harassment includes offensive communication related to gender, sexual
+orientation, disability, physical appearance, body size, race, religion, sexual
+images in public spaces, deliberate intimidation, stalking, following,
+harassing photography or recording, sustained disruption of talks or other
+events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behaviour are expected to comply
+immediately.
+
+Be careful in the words that you choose. Remember that words can be offensive
+to those around you. Offensive jokes are not acceptable at the
+2nd International RSE Leaders Meeting.
+Excessive swearing is not appropriate at this event.
+
+If a participant engages in behaviour that violates this code of conduct, the
+workshop organisers may take any action they deem appropriate, including
+warning the offender or expulsion from the workshop with no refund.
+
+
+## Procedure for reporting harassment
+
+If you are being harassed, notice that someone else is being harassed, or have
+any other concerns, please contact any member of the code of conduct committee:
+
+**Here we will list members of the code of conduct committee.**
+
+Report the harassment incident via email to a member of the code of conduct
+committee. All reports are confidential.
+
+When reporting the event to a code of conduct committee member, try to gather
+as much information as available, but do not interview people about the
+incident. The committee member will assist you in writing the report/collecting
+information.
+
+The important information we need consists of:
+- Identifying information (name) of the participant doing the harassing
+- The behaviour that was in violation
+- The approximate time of the behaviour (if different than the time the report was made)
+- The circumstances surrounding the incident
+- Other people involved in the incident
+
+The code of conduct committee is well informed on how to deal with the incident
+and how to further proceed with the situation.  All of our committee members
+are informed of the code of conduct policy and guide for handling harassment at
+the workshop. There will be a mandatory code of conduct committee meeting just
+prior to the event when this will be reiterated as well.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -67,9 +67,13 @@ warning the offender or expulsion from the workshop.
 ## Procedure for reporting harassment
 
 If you are being harassed, notice that someone else is being harassed, or have
-any other concerns, please contact any member of the code of conduct committee:
+any other concerns, please contact any member of the code of conduct committee
+via email or direct message using the workshop Slack chat:
 
-**Here we will list members of the code of conduct committee.**
+- Anne Fouilloux
+- Ian Cosden
+- Radovan Bast (radovan.bast@uit.no)
+
 
 Report the harassment incident via email to a member of the code of conduct
 committee. All reports are confidential.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -96,5 +96,5 @@ enforced immediately.
 The code of conduct committee is well informed on how to deal with the incident
 and how to further proceed with the situation.  All of our committee members
 are informed of the code of conduct policy and guide for handling harassment at
-the workshop. There will be a mandatory code of conduct committee meeting just
-prior to the event when this will be reiterated as well.
+the workshop. There will be a mandatory meeting for the code of conduct
+committee members just prior to the event when this will be reiterated as well.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -71,7 +71,7 @@ any other concerns, please contact any member of the code of conduct committee
 via email or direct message using the workshop Slack chat:
 
 - Anne Fouilloux (annefou@uio.no)
-- Ian Cosden
+- Ian Cosden (icosden@princeton.edu)
 - Radovan Bast (radovan.bast@uit.no)
 
 Report the harassment incident via email to a member of the code of conduct


### PR DESCRIPTION
Origin of this:

> This code of conduct is copied and adapted from the code of conduct used at the
> [Collaborations Workshop 2020](https://www.software.ac.uk/cw20/code-conduct)
> (CC-BY-NC 2.5 license) which was adapted from the example policy at the
> [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy),
> created by the Ada Initiative and other volunteers (CC-0 license).
> The procedure for reporting harassment has been adopted from the Ada Initiative's guide titled
> ["workshop anti-harassment/Responding to Reports"](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports).

We need to modify "Here we will list members of the code of conduct committee". Set as draft PR until we modify this.

Can you please have a look @annefou @cosden?