### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ We may ask you for further details, and discuss the enhancement further.
 
 # Code of Conduct
 
-You are required to adhere to our Code of Conduct during all parts of your interaction with this project.
+You are required to adhere to our [Code of Conduct](https://researchsoftware.org/council/code-of-conduct.html) during all parts of your interaction with this project.
 
 # Thank you, we'd like to recognize your contribution!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please read these guidelines carefully to learn about how to contribute.
 # How to submit contributions
 
 Please submit your contribution via a Pull Request (PR).
-You can learn how to create a Pull Reuest in the [GitHub documentation](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+You can learn how to create a Pull Request in the [GitHub documentation](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 Once your Pull Request is ready, please request a review.
 To do so, please simply add a comment to that effect to the Pull Request discussion.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,8 @@ Please feel free to ask any questions in PR comments during this process.
 
 All content contributions to this repository are accepted under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/). Note that by contributing, you accept that your content contributions are published under this license.
 
-"Insignificant" files such as configuration, template, theme-related, and meta files (such as this one) are licensed under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.en). By making contributions to such files, you accept that your contribution is licensed under this license.
+"Insignificant" files such as configuration, template, theme-related, and meta files (such as this one) are licensed under [CC0 1.0 Universal (CC0 1.0)
+Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed.en). By making contributions to such files, you accept that your contribution is licensed under this license.
 
 # How to report a bug or an issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ All content contributions to this repository are accepted under a [Creative Comm
 
 # How to report a bug or an issue
 
-Please create a new issue report in the issue tracker for this repository, and describe the issue you have found.
+Please create a [new issue report](https://github.com/RSE-leaders/researchsoftware.org/issues/new/choose) in the [issue tracker for this repository](https://github.com/RSE-leaders/researchsoftware.org/issues), and describe the issue you have found.
 We will try to answer your report in due time.
 
 # How to request an improvement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ We will try to answer your report in due time.
 
 # How to request an improvement
 
-Please create a new issue report in the issue tracker for this repository, and describe the improvement you would like to see.
+Please create a [new issue report](https://github.com/RSE-leaders/researchsoftware.org/issues/new/choose) in the [issue tracker for this repository](https://github.com/RSE-leaders/researchsoftware.org/issues), and describe the improvement you would like to see.
 We will try to answer your request in due time.
 We may ask you for further details, and discuss the enhancement further.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please feel free to ask any questions in PR comments during this process.
 
 ## Licenses
 
-All content contributions to this repository are accepted under a [Creative Commons Attribution 4.0 International license](LICENSE). Note that by contributing you accept that your content contributions are published under this license.
+All content contributions to this repository are accepted under a [Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/). Note that by contributing, you accept that your content contributions are published under this license.
 
 "Insignificant" files such as configuration, template, theme-related, and meta files (such as this one) are licensed under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.en). By making contributions to such files, you accept that your contribution is licensed under this license.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Welcome!
 
-We are happy that you are considering to contribute to the researchsoftware.org website!
+We are happy that you are considering contributing to the [researchsoftware.org](https://researchsoftware.org) website!
 Please read these guidelines carefully to learn about how to contribute.
 
 # How to submit contributions
 
 Please submit your contribution via a Pull Request (PR).
-You can learn how to create a Pull Request in the [GitHub documentation](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+You can learn how to create a Pull Request in [GitHub's documentation](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
 Once your Pull Request is ready, please request a review.
 To do so, please simply add a comment to that effect to the Pull Request discussion.
 
@@ -24,8 +24,8 @@ Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/deed
 
 # How to report a bug or an issue
 
-Please create a [new issue report](https://github.com/RSE-leaders/researchsoftware.org/issues/new/choose) in the [issue tracker for this repository](https://github.com/RSE-leaders/researchsoftware.org/issues), and describe the issue you have found.
-We will try to answer your report in due time.
+Please create a [new issue report](https://github.com/RSE-leaders/researchsoftware.org/issues/new/choose) in the [issue tracker for this repository](https://github.com/RSE-leaders/researchsoftware.org/issues), and describe the bug you have found or the issue that concerns you.
+We will try to respond to your report in due time.
 
 # How to request an improvement
 
@@ -39,7 +39,7 @@ You are required to adhere to our [Code of Conduct](https://researchsoftware.org
 
 # Thank you, we'd like to recognize your contribution!
 
-We are grateful for your contribution, and would like to recognize this by adding you to a list of contributors in the [README file](README.md) for this project.
+We are grateful for all contributions, and would like to recognize this by adding those who make them to a list of contributors in the [README file](README.md) for this project.
 To do so, we use some automation provided by the [*All Contributors* project](https://allcontributors.org/).
 This means that you can request to be added as a contributor yourself by adding a comment in your PR or issue, similar to this: `@all-contributors please add @<username> for `[`<contributions>`](https://allcontributors.org/docs/en/emoji-key).
 Please read the [All Contributors documentation](https://allcontributors.org/docs/en/bot/usage) for more details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Welcome!
+
+We are happy that you are considering to contribute to the researchsoftware.org website!
+Please read these guidelines carefully to learn about how to contribute.
+
+# How to submit contributions
+
+Please submit your contribution via a Pull Request (PR).
+You can learn how to create a Pull Reuest in the [GitHub documentation](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+Once your Pull Request is ready, please request a review.
+To do so, please simply add a comment to that effect to the Pull Request discussion.
+
+We will try to review your PR in due time, but do not make any promises.
+You can expect to receive comments about your contribution from the reviewer or reviewers.
+These may simply accept your contribution and thank you for it, or they may ask you to make changes, or even suggest changes themselves.
+Please feel free to ask any questions in PR comments during this process.
+
+## Licenses
+
+All content contributions to this repository are accepted under a [Creative Commons Attribution 4.0 International license](LICENSE). Note that by contributing you accept that your content contributions are published under this license.
+
+"Insignificant" files such as configuration, template, theme-related, and meta files (such as this one) are licensed under [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/deed.en). By making contributions to such files, you accept that your contribution is licensed under this license.
+
+# How to report a bug or an issue
+
+Please create a new issue report in the issue tracker for this repository, and describe the issue you have found.
+We will try to answer your report in due time.
+
+# How to request an improvement
+
+Please create a new issue report in the issue tracker for this repository, and describe the improvement you would like to see.
+We will try to answer your request in due time.
+We may ask you for further details, and discuss the enhancement further.
+
+# Code of Conduct
+
+You are required to adhere to our Code of Conduct during all parts of your interaction with this project.
+
+# Thank you, we'd like to recognize your contribution!
+
+We are grateful for your contribution, and would like to recognize this by adding you to a list of contributors in the [README file](README.md) for this project.
+To do so, we use some automation provided by the [*All Contributors* project](https://allcontributors.org/).
+This means that you can request to be added as a contributor yourself by adding a comment in your PR or issue, similar to this: `@all-contributors please add @<username> for `[`<contributions>`](https://allcontributors.org/docs/en/emoji-key).
+Please read the [All Contributors documentation](https://allcontributors.org/docs/en/bot/usage) for more details.
+
+# Who is involved in *researchsoftware.org*?
+
+The **International Council of RSE Associations** is the owner of this repository.
+You can get in touch with us to get help, and ask questions about, or discuss, your contribution before you start working on it.
+For contact details, please see the [Council website](https://researchsoftware.org/council.html).
+
+---
+
+![CC0-1.0 license badge](https://img.shields.io/badge/license-CC0--1.0-blue)


### PR DESCRIPTION
This PR

- adds contribution guidelines in `CONTRIBUTING.md`
- adds use of the [all-contributors](https://allcontributors.org/) bot