### PR TITLE
Add Council CoC page

### DIFF
--- a/council.md
+++ b/council.md
@@ -31,6 +31,8 @@ To get in touch with the Council, write an email to
 For more information, also read 
 [this blog post from the 2nd International RSE Leaders Workshop 2020](https://researchsoftware.org/2021/01/27/introducing-the-international-council-of-RSE-associations.html).
 
+The Council has a [*Code of Conduct*](./council/code-of-conduct.md), and you are expected to honour it in any participation in or interaction with the Council.
+
 ## Current members
 
 | Association | Name | Email |
@@ -49,4 +51,3 @@ For more information, also read
 | Nordic-RSE  | Radovan Bast | radovan.bast@uit.no |
 | US-RSE  | Daniel S. Katz | d.katz@ieee.org |
 | US-RSE  | Ian Cosden | icosden@princeton.edu |
-

--- a/council/code-of-conduct.md
+++ b/council/code-of-conduct.md
@@ -1,0 +1,327 @@
+---
+layout: page
+title: The International Council of RSE Associations - Code of Conduct
+hidetitle: false
+---
+
+
+## The short version
+
+If you have a question about the code of conduct or wish to report
+misconduct, please email the International Council of RSE Associations
+(the Council) at
+[*intl-rse-council@listserv.dfn.de*](mailto:intl-rse-council@listserv.dfn.de),
+the rotating chair of the next Council meeting, or [*any member of the
+Council*](https://researchsoftware.org/council.html).
+
+Be kind to others. Do not insult or put down others. Behave
+professionally. Remember that harassment and sexist, racist, or
+exclusionary jokes are not appropriate for the International Council of
+RSE Associations.
+
+All communication should be appropriate for a professional audience
+including people of many different backgrounds. Sexual language and
+imagery are not appropriate.
+
+The International Council of RSE Associations is dedicated to providing
+a harassment-free community for everyone, regardless of age, disability,
+gender reassignment, marriage and civil partnership, pregnancy and
+parenthood, race, religion or belief (or lack thereof), gender identity
+and expression, sex, sexual orientation, technical choices, experience
+level or any other dimension of diversity. We do not tolerate harassment
+of community members in any form.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+## About the Code of Conduct
+
+The International Council of RSE Associations (the Council) provides a
+formal open forum for established national and multinational RSE
+associations to talk and coordinate regularly, and thus sustain
+international collaboration. We are committed to creating a welcoming
+and supportive environment for all of our members. All participants in
+our events and communications are expected to show respect and courtesy
+to others.
+
+This Code of Conduct should be honoured by everyone who participates in
+the International Council of RSE Associations, as member, guest, or in
+another role. It should be honoured in all Council activities, by anyone
+claiming affiliation with the Council, and especially when someone is
+representing the Council in any role (including as an event volunteer,
+organiser or speaker).
+
+This Code of Conduct outlines our behaviour expectations as members of
+the Council in all Council activities, both offline and online.
+Everyone's participation is contingent upon following these guidelines
+in all activities associated with the Council including but not limited
+to:
+
+-   Council meetings
+-   Email lists and online forums like Slack, Twitter, GitHub, and
+    LinkedIn
+-   Representing the Council at public events
+
+As a relatively small organization, the Council itself is responsible
+for enforcing the Code of Conduct and all reports about misconduct will
+be dealt with promptly and in accordance with the Enforcement* *Manual
+(see below).
+
+Behaviours that are disrespectful to our members or events' attendees
+and sponsors, or intimidate, exclude or cause discomfort to others will
+not be tolerated. We do not tolerate discrimination or harassment based
+on characteristics that include, but are not limited to, age,
+disability, gender reassignment, marriage and civil partnership,
+pregnancy and parenthood, race, religion or belief (or lack thereof),
+gender identity and expression, sex, sexual orientation, technical
+choices, experience level or any other dimension of diversity.
+
+The Council is responsible for the enforcement of this Code of Conduct
+and for dealing with misconduct or violations to this policy. Council
+members are expected to assist with the enforcement of the Code of
+Conduct in their respective capacities. By participating, individuals
+indicate their acceptance of the procedures by which the Council
+resolves any Code of Conduct incidents, which might include storage and
+processing of their personal information.
+
+## Expected behaviour
+
+All participants in our events and communications are expected to show
+respect and courtesy to others and all interactions should be
+professional, both online and in-person.
+
+The following kinds of behaviours in all Council events and platforms
+are encouraged:
+
+-   Focusing on what is best for the community
+-   Showing courtesy and respect towards every member of the community
+-   Being respectful of different viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Using welcoming and inclusive language
+-   Adhering to the Code of Conduct
+-   Being direct, but professional
+-   Asking for consent and respecting people's boundaries
+-   Being aware of the dynamics of power and privilege (be mindful of
+    how much time and space you are taking up)
+
+## Unacceptable behaviour
+
+Examples of unacceptable behaviour include:
+
+-   Publication of private communication without consent
+-   Excessive swearing
+-   Improper gestures
+-   Use of stereotypes
+-   Incitement to violence, suicide or self-harm
+-   Sustained disruptions of talks, workshops events or communications
+-   The display of violent images
+-   Causing someone to fear for their safety through stalking,
+    following, intimidation, or threatening
+-   Unwelcome and repeated flirtations, propositions, advances, or other
+    sexual attention -- including gratuitous or off-topic sexual images
+    or behaviour
+-   Non-consensual or unwelcome physical contact
+-   Sexist, racist, homophobic, transphobic, ableist, or exclusionary
+    jokes
+-   Continuing to initiate interaction with someone after being
+    explicitly asked to stop
+-   Offensive, insulting, derogatory, or degrading remarks
+-   Demands for sexual favours in exchange for favourable or
+    preferential treatment
+-   Advocating for, or encouraging any of the above behaviours
+
+## Consequences of Unacceptable Behaviour
+
+Participants who are asked to stop any inappropriate behaviour are
+expected to comply immediately. This applies to any event or platform,
+either online or in-person. If an event participant engages in behaviour
+that violates this code of conduct, the organizers may warn the
+offender, ask them to leave the event or platform (without refund), or
+engage the Council to investigate the Code of Conduct violation and
+impose appropriate sanctions.
+
+## Incident reporting guidelines
+
+If you believe that someone is violating the Code of Conduct, please
+report this in a timely manner. Code of Conduct violations reduce the
+value of the community for everyone. The Council takes reports of
+misconduct very seriously and is committed to preserving and maintaining
+the welcoming nature of our community.
+
+**All reports will be kept confidential.**
+
+Any violations to the Code of Conduct during Council events should be
+immediately reported to the event host, organiser or the designated
+incident person/people. The people handling the incident report should
+also make a direct report to the Council by emailing the rotating chair
+of the next Council meeting. If you are uncomfortable emailing this
+rotating chair, incidents can also be reported directly to any Council
+member.
+
+If the violation occurs in an online space, reports should be emailed
+directly to the rotating chair of the next meeting or any other Council
+[*member*](https://researchsoftware.org/council.html).
+
+The person to whom a report is made is hereafter referred to as \"the
+Contact\".
+
+All reports will be reviewed by the Council and will be kept
+confidential to the extent possible in a small group.
+
+In your report, please do your best to include:
+
+-   Your contact information
+-   Identifying information of the reported person
+-   The behaviour associated with the Code of Conduct violation
+-   If possible, where the Code of Conduct violation happened
+-   The approximate time of the behaviour (if different than the time
+    the report was made)
+-   The circumstances surrounding the incident
+-   Other people involved or that witnessed the incident
+-   If there is a publicly available record (i.e. email thread, Slack
+    messages, Twitter threads)
+-   If you believe this is an ongoing situation, please let us know
+-   Any additional helpful information
+
+## What to do if someone is in immediate danger?
+
+If you believe someone is in immediate danger, please ask a Council
+member to contact appropriate emergency responders. All event organizers
+should, before the event, determine who would be appropriate to contact
+in case of an incident and make sure this information is available at
+all times over the duration of the event in question.
+
+Once the incident has been resolved, we ask that it be reported to the
+Council in the same way as all other incidents.
+
+## Enforcement manual
+
+The following section details the enforcement manual followed by the
+Council. It is used when we respond to an issue to make sure we are
+consistent and fair on every instance. Enforcement of the Code of
+Conduct should be respectful and not include any harassing behaviours.
+
+All responses to reports of conduct violations will be managed by the
+Council itself.. To write to the Council and for the current membership,
+see
+[*https://researchsoftware.org/council.html*](https://researchsoftware.org/council.html).
+
+### How will the Council respond to reports?
+
+When a report is sent to the Council, a member will reply to the report
+to confirm receipt within 24 hours. If a report does not contain enough
+information, the Council will attempt to obtain all relevant data before
+acting, including contacting any individuals involved to get a
+comprehensive account of events. Once a report has been filed, one of
+the Council members will be assigned as the main acting member
+responsible for any communications with the involved individual(s).
+
+The Council is also empowered to act if any of its members becomes aware
+of ongoing behaviour that, taken as a whole over a long time period, is
+disrupting or harassing. Such behaviour might not be "over the line" in
+any single incident, and thus may not generate a report.
+
+### Immediate response
+
+The initial response to an incident is very important. Depending on the
+severity and details of the incident, an immediate response may be
+required.
+
+In situations involving immediate danger or involving a threat to
+anyone's safety, any member of the Council may -- and should -- act
+immediately to protect the safety of the individual(s) in such a
+situation. This can include contacting law enforcement or crisis
+resources.
+
+If a Council member acts before reviewing the situation within the
+Council, , they must inform the other Council members as soon as
+possible, and report their actions to the Council for review within 24
+hours.
+
+### Ongoing incidents
+
+If the action is ongoing, whether in person or online, any Council
+member may act immediately and employ any available means to diffuse the
+situation including bans and blocks. In situations where an individual
+Council member acts immediately, they must inform the other Council
+members as soon as possible, and report their actions to the Council for
+review within 24 hours.
+
+### Less-urgent situations
+
+Once a report is filed, the Council will review the incident and
+determine, to the best of their ability:
+
+-   Whether this is an ongoing situation
+-   Whether there is a threat to anyone's safety
+-   What happened
+-   Whether this event constitutes a code of conduct violation
+-   Who, if anyone, was the bad actor
+-   Whether any communications should be made to the wider community
+
+This information will be collected in writing, and whenever possible the
+Council's deliberations will be recorded and retained (e.g., email
+discussions, recorded voice conversations, etc).
+
+The Council should aim to have a resolution agreed upon within one week.
+In the event that a resolution can't be determined in that time, the
+Council will respond to the reporter(s) with an update and the projected
+timeline for resolution.
+
+### Resolutions
+
+The Council must agree on a resolution by consensus of all members
+investigating the report in question.
+
+Possible outcomes may include:
+
+-   Taking no further action (if it is determined that there was no
+    violation).
+-   A private reprimand from the Council to the individual(s) involved.
+    In this case, the Contact will deliver that reprimand to the
+    individual(s) over email, cc'ing the Council.
+-   Ending a talk that violates the Code of Conduct early
+-   A public announcement of an incident, ideally in the same venue that
+    the violation occurred.
+-   Immediately ending any event volunteer responsibilities and
+    privileges the individual(s) hold(s).
+-   An imposed suspension from the Council platforms. The Contact will
+    communicate this suspension to the individual(s). They'll be asked
+    to take this suspension voluntarily, but if they don't agree then a
+    temporary ban may be imposed to enforce this suspension.
+-   A permanent or temporary ban from some or all Council spaces.
+-   Assistance to the complainant with a report to other bodies, for
+    example, institutional offices or appropriate law enforcement
+    agencies.
+
+Once a resolution is agreed upon, but before it is enacted, the Council
+will contact the original reporter and any other affected parties and
+explain the proposed resolution. The Council will ask if this resolution
+is acceptable, and must note feedback for the record. However, the
+Council is not required to act on this feedback.
+
+### Conflicts of interest
+
+In the event of any conflict of interest (a Council member, their family
+member, or someone with whom the Council member has a close academic,
+employment, or personal relationship is involved in a complaint), the
+Council member must immediately notify the other members, and recuse
+themselves if necessary.
+
+## Acknowledgements
+
+We would like to thank the individuals, communities, and projects whose
+work significantly contributed to this Code of Conduct:
+
+-   The [*Society of Research Software Engineering's Code of Conduct*](https://society-rse.org/about/code-of-conduct/), which is
+    the direct source of the basis of this Code of Conduct. It in turn thanks 
+    [*Mozilla participation guidelines*](https://www.mozilla.org/en-US/about/governance/policies/participation/),
+    the [*Carpentries code of conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html),
+    and the [*OpenCon 2018 Code of Conduct*](https://www.opencon2018.org/code_of_conduct),
+    which served as an inspiration for the Society.
+-   The section outlining our processes for responding to Code of Conduct violations were again liberally borrowed from the 
+    [*RSE Society's equivalent*](https://society-rse.org/about/code-of-conduct/), which
+    was greatly inspired or derived from the
+    [*PyCon 2018 code of conduct*](https://2018.pyconuk.org/code-conduct/), the Geek Feminism
+    Wiki created by the [*Ada Initiative*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports),
+    particularly their [*Conference anti-harassment*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)
+    section, and the [*Django project*](https://www.djangoproject.com/conduct/enforcement-manual/).


### PR DESCRIPTION
- Add a page with the Council's CoC as accepted during the Council meeting on 2021-06-07 (page does *not* have its own nav item)
- Add a link to the CoC page from the main page