### PR TITLE
Add page for intl RSE day and link from index

### DIFF
--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -4,7 +4,7 @@ title: International RSE Day
 hidetitle: false
 ---
 
-The [International Council of RSE Associations](council.md) has decided to declare 
+The [International Council of RSE Associations](../council.md) has decided to declare 
 the second Thursday in October to be the annual "International RSE Day". 
 
 ### The first International RSE Day will be<br>*Thursday, 14th October 2021*.

--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: International RSE Day
+hidetitle: false
+---
+
+The [International Council of RSE Associations](council.md) has decided to declare 
+the second Thursday in October to be the annual "International RSE Day". 
+
+### The first International RSE Day will be<br>*Thursday, 14th October 2021*.
+
+The International RSE Day is to celebrate Research Software Engineers around the world 
+and raise awareness for the increasingly relevant discipline of Research Software 
+Engineering. The International Council encourages national and local RSE associations to 
+hold regular or special events on this day, such as:
+
+* Keynote talks
+* Networking events
+* National meetups, possibly in combination with the annual AGM
+* Awareness campaigns
+* National RSE information sessions
+
+## International RSE Day 2021 - Events
+
+- ### **[NL-RSE]** [NL-RSE Road Show](https://nl-rse.org/events/NL-RSE-RSE21.html)

--- a/index.md
+++ b/index.md
@@ -8,6 +8,11 @@ This is the website of the international research software engineering community
 
 Research Software Engineers are people who combine professional software expertise with an understanding of research. They go by various job titles but the term Research Software Engineer (RSE) is fast gaining international recognition.
 
+<div style="position: relative; height: auto; border: 2px solid #841b5f; margin: 10px auto; padding: 10px; box-sizing: border-box; background-color: #f0e1e8; border-radius: 5px;">
+<h3 style="padding: 0; margin: 0;">14th October 2021 is <i>International RSE Day</i>!<br>
+<a href="council/intl-rse-day/">Read more ...</a></h3>
+</div>
+
 # National RSE Associations
 
 [Society of Research Software Engineering - UK](https://society-rse.org/)  <br />


### PR DESCRIPTION
This adds a page for the intl RSE day, and a box with a link to the page to the landing page, see screenshots.

![image](https://user-images.githubusercontent.com/3007126/135225439-6b5849dd-df8b-4f06-b144-c9cec838fcea.png)

---

![image](https://user-images.githubusercontent.com/3007126/135225495-b5bb0940-9cc7-4b4a-9ad4-75c00dc3e399.png)
