### PR TITLE
Add AUS RSE/RS BOF to Intl RSE Day events

### DIFF
--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -24,3 +24,7 @@ hold regular or special events on this day, such as:
 
 - ### **[NL-RSE]** [NL-RSE Road Show](https://nl-rse.org/events/NL-RSE-RSE21.html)
 - ### **[Nordic-RSE]** [Nordic-RSE celebrates International RSE day](https://nordic-rse.org/events/international-rse-day/)
+
+### Related events
+
+- #### **[Australia]** ["Data is Only Half the Battle"](https://conference.eresearch.edu.au/events/data-is-only-half-the-battle/) - RSE & Research software management BOF

--- a/council/intl-rse-day.md
+++ b/council/intl-rse-day.md
@@ -25,6 +25,6 @@ hold regular or special events on this day, such as:
 - ### **[NL-RSE]** [NL-RSE Road Show](https://nl-rse.org/events/NL-RSE-RSE21.html)
 - ### **[Nordic-RSE]** [Nordic-RSE celebrates International RSE day](https://nordic-rse.org/events/international-rse-day/)
 
-### Related events
+### Related events on Intl RSE Day
 
 - #### **[Australia]** ["Data is Only Half the Battle"](https://conference.eresearch.edu.au/events/data-is-only-half-the-battle/) - RSE & Research software management BOF


### PR DESCRIPTION
Adds a section "related events" and the [Data is Only Half the Battle]() BOF to the page for Intl RSE Day 2021.

:warning: Pending reply on request to add this to the page from Paula Andrea. Only to be merged if they agree.

![image](https://user-images.githubusercontent.com/3007126/136155708-60571848-d1ba-4ab3-808f-7a94a8a92ceb.png)

